### PR TITLE
Disable default search path when cross-compiling for Android

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -77,6 +77,11 @@ class Log4cplusConan(ConanFile):
         cmake.definitions['LOG4CPLUS_WORKING_LOCALE'] = self.options.working_locale
         cmake.definitions['LOG4CPLUS_WORKING_C_LOCALE'] = self.options.working_c_locale
 
+        if self.settings.os == 'Android':
+            cmake.definitions['CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM'] = 'ONLY'
+            cmake.definitions['CONAN_CMAKE_FIND_ROOT_PATH_MODE_LIBRARY'] = 'ONLY'
+            cmake.definitions['CONAN_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE'] = 'ONLY'
+
         cmake.configure(build_dir=self.build_subfolder)
         cmake.build()
         cmake.install()


### PR DESCRIPTION
### Problem

When cross-compiling on linux host, cmake find host library `/usr/lib32/librt.so` instead of NDK's one

```
-- Looking for clock_gettime in /usr/lib32/librt.so
-- Looking for clock_gettime in /usr/lib32/librt.so - not found
-- Looking for clock_nanosleep in /usr/lib32/librt.so
-- Looking for clock_nanosleep in /usr/lib32/librt.so - not found
-- Looking for nanosleep in /usr/lib32/librt.so
-- Looking for nanosleep in /usr/lib32/librt.so - not found
```

As result:

```
/Users/camobap/.conan/data/log4cplus/1.2.1/bincrafters/stable/build/8a9ebf49259b50bc3e8502b3075e3ed240faf122/source_subfolder/src/sleep.cxx:61:4: error: no nanosleep() or clock_nanosleep()
#  error no nanosleep() or clock_nanosleep()
   ^
1 error generated.
make[2]: *** [source_subfolder/src/CMakeFiles/log4cplus.dir/sleep.cxx.o] Error 1
```

### Proposed solution

log4cplus internally use https://github.com/log4cplus/log4cplus/blob/1.2.x/android/android.toolchain.cmake#L1568

Which define:
 - `set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY )`
 - `set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )`
 - `set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )`

Also 'official' google cmake toolchain do the same https://android.googlesource.com/platform/ndk/+/master/build/cmake/android.toolchain.cmake#290

So maybe make sense to enable it by default (PR for conan) IDK I'm ready to discuss this