### PR TITLE
UNICODE definition added

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -28,7 +28,8 @@ class Log4cplusConan(ConanFile):
                "working_c_locale": [True, False],
                "decorated_name": [True, False],
                "qt4_debug_appender": [True, False],
-               "qt5_debug_appender": [True, False]}
+               "qt5_debug_appender": [True, False],
+               "unicode": [True, False]}
     default_options = ('shared=False',
                        'fPIC=True',
                        "single_threaded=False",
@@ -38,7 +39,8 @@ class Log4cplusConan(ConanFile):
                        "working_c_locale=False",
                        "decorated_name=False",
                        "qt4_debug_appender=False",
-                       "qt5_debug_appender=False")
+                       "qt5_debug_appender=False",
+                       "unicode=False")
     short_paths = True
 
     def requirements(self):
@@ -76,6 +78,7 @@ class Log4cplusConan(ConanFile):
         cmake.definitions['WITH_ICONV'] = self.options.with_iconv
         cmake.definitions['LOG4CPLUS_WORKING_LOCALE'] = self.options.working_locale
         cmake.definitions['LOG4CPLUS_WORKING_C_LOCALE'] = self.options.working_c_locale
+        cmake.definitions['UNICODE'] = self.options.unicode
 
         if self.settings.os == 'Android':
             cmake.definitions['CONAN_CMAKE_FIND_ROOT_PATH_MODE_PROGRAM'] = 'ONLY'

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -8,11 +8,6 @@ conan_basic_setup()
 
 file(GLOB SOURCE_FILES *.cpp)
 
-if(MSVC)
-    add_definitions("-DUNICODE")
-    add_definitions("-D_UNICODE")
-endif()
-
 if(WITH_ICONV)
     add_definitions("-DWITH_ICONV")
 endif()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -8,10 +8,13 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
+    options = {"unicode": [True, False]}
+    default_options = ("unicode=False")
 
     def build(self):
         cmake = CMake(self)
         cmake.definitions['WITH_ICONV'] = self.options['log4cplus'].with_iconv
+        cmake.definitions['UNICODE'] = self.options['log4cplus'].unicode
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
CMake definition "unicode" was added. Its possible values are ON/OFF (OFF by default).
Can be overridden during package installation with command line argument '-o unicode="ON"' (or by defining this option in profile)
Tested on CentOS and Windows platforms.

Please review if this changes could be safely applied.